### PR TITLE
Change function call ordering

### DIFF
--- a/lib/psql_autocomplete.rb
+++ b/lib/psql_autocomplete.rb
@@ -17,11 +17,8 @@ module PsqlAutocomplete
   end
 
   def sql_sanitize_column(unaccent, field)
-    res = "coalesce(lower(regexp_replace(#{field}, '[:'']', '', 'g')), '')"
-
-    return res unless unaccent
-
-    "unaccent(#{res})"
+    value = unaccent ? "unaccent(#{field})" : field
+    "coalesce(lower(regexp_replace(#{value}, '[:'']', '', 'g')), '')"
   end
 
   def tsquery(sentence, unaccent)

--- a/spec/psql_autocomplete_spec.rb
+++ b/spec/psql_autocomplete_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PsqlAutocomplete do
     it 'handles unaccent' do
       input = ['Foo & baR', [:Title, :boDy], unaccent: true]
 
-      tsvector = "(unaccent(coalesce(lower(regexp_replace(Title, '[:'']', '', 'g')), '')) || ' ' || unaccent(coalesce(lower(regexp_replace(boDy, '[:'']', '', 'g')), '')))::tsvector"
+      tsvector = "(coalesce(lower(regexp_replace(unaccent(Title), '[:'']', '', 'g')), '') || ' ' || coalesce(lower(regexp_replace(unaccent(boDy), '[:'']', '', 'g')), ''))::tsvector"
       tsquery = "unaccent($$'foo':* & '&':* & 'bar':*$$)::tsquery"
 
       expect(ModelDouble.autocomplete_query(*input)).


### PR DESCRIPTION
With some DB configuration, `unaccent` will transform typographic quotes
to straight quotes :

``` sql
select unaccent($$’’big data’’$$) -- -> ''big data''
```

This will lead to errors when trying to cast to tsvector.

By calling `unaccent` before the `regexp_replace` that takes care of
straight quotes, we get rid of the error.